### PR TITLE
Fixed typo that prevented using code25interleaved barcode implementation

### DIFF
--- a/README-PL.markdown
+++ b/README-PL.markdown
@@ -517,7 +517,7 @@ Przykład:
 
 Tag &lt;barcode&gt; obsługuje większość standardowych atrybutów oraz ma szereg innych atrybutów:
 
-* type - typ kodu kreskowego, dozwolone wartości: code128, code25, code25interlayed, code39, ean13, ean2, ean5, ean8, identcode, itf14, leitcode, planet, postnet, royalmail, upca, upce
+* type - typ kodu kreskowego, dozwolone wartości: code128, code25, code25interleaved, code39, ean13, ean2, ean5, ean8, identcode, itf14, leitcode, planet, postnet, royalmail, upca, upce
 * draw-code - odpowiednik opcji drawCode z Zend\Barcode
 * bar-height - odpowiednik opcji barheight z Zend\Barcode
 * with-checksum - odpowiednik opcji withChecksum z Zend\Barcode

--- a/README.markdown
+++ b/README.markdown
@@ -598,7 +598,7 @@ Example:
 
 ```<barcode>``` tag supports the most of standard attributes and has some other attributes:
 
-* type - typ of barcode, supported values: code128, code25, code25interlayed, code39, ean13, ean2, ean5, ean8, identcode, itf14, leitcode, planet, postnet, royalmail, upca, upce
+* type - typ of barcode, supported values: code128, code25, code25interleaved, code39, ean13, ean2, ean5, ean8, identcode, itf14, leitcode, planet, postnet, royalmail, upca, upce
 * draw-code - equivalent of drawCode option from Zend\Barcode
 * bar-height - equivalent of barHeight option from Zend\Barcode
 * with-checksum - equivalent of withChecksum option from Zend\Barcode

--- a/lib/PHPPdf/Core/Node/Barcode.php
+++ b/lib/PHPPdf/Core/Node/Barcode.php
@@ -24,7 +24,7 @@ class Barcode extends Node
 {
     const TYPE_CODE128 = 'code128';
     const TYPE_CODE25 = 'code25';
-    const TYPE_CODE25INTERLEAYED = 'code25interlayed';
+    const TYPE_CODE25INTERLEAVED = 'code25interleaved';
     const TYPE_CODE39 = 'code39';
     const TYPE_EAN13 = 'ean13';
     const TYPE_EAN2 = 'ean2';


### PR DESCRIPTION
I tried to use code interleaved 2 of 5 for a barcode and was getting an InvalidArgumentException. It was a simple typo on the class const definitions.
