### PR TITLE
composer: fixes autoload section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     	"imagine/Imagine": "If you want to use image generating (required version: >=v0.2.6)"
     },
     "autoload": {
-        "psr-0": { "PHPPdf": "lib/", "Imagine": "lib/" }
+        "psr-0": { "PHPPdf": "lib/" }
     }
 }


### PR DESCRIPTION
This patch removes the definition of namespace "Imagine" (mapped on local lib/) as it is an external library and could corrupt main application's autoloader
