### PR TITLE
Do not return $src unmodified when value is NULL

### DIFF
--- a/lib/PHPPdf/Core/Node/Image.php
+++ b/lib/PHPPdf/Core/Node/Image.php
@@ -199,6 +199,6 @@ class Image extends Node
     {
         $src = $this->getAttribute('src');
 
-        return is_string($src) ? $this->createSource($document) : $src;
+        return is_string($src) || $src === null ? $this->createSource($document) : $src;
     }
 }


### PR DESCRIPTION
If, for some reason, the src attribute of an image has a NULL value, it is returned directly.
This results in method calls on a NULL-object, triggering a fatal error. This fix checks not only
if $src is a string, but also if it is NULL, and passes the NULL value to Image::createSource() to
allow for better error handling.
