### PR TITLE
Fix non-explicit dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }     
     ],
     "require": {
-        "zendframework/zendpdf":  ">=2.0.0-rc2",
-        "zendframework/zend-cache":  ">=2.0.0-rc2",
-        "zendframework/zend-memory": ">=2.0.0-rc2"
+        "zendframework/zendpdf":  "2.*,<2.3",
+        "zendframework/zend-cache":  "2.*,<2.3",
+        "zendframework/zend-memory": "2.*,<2.3"
     },
     "suggest": {
     	"zendframework/zend-barcode":  "If you want to use barcodes",


### PR DESCRIPTION
Hello @psliwa 

I'm getting this error today

```
Problem 1
    - zendframework/zend-cache 2.3.x-dev requires zendframework/zend-eventmanager == 2.3.9999999.9999999-dev -> no matching package found.
    - zendframework/zend-cache 2.3.x-dev requires zendframework/zend-eventmanager == 2.3.9999999.9999999-dev -> no matching package found.
    - Installation request for zendframework/zend-cache 2.3.x-dev -> satisfiable by zendframework/zend-cache[2.3.x-dev]
```

Previous `composer.json` will fail (started from 2014-08-12 11:58 UTC) on anyone project that require this library with minimum stability `dev` since `zendframework/zend-eventmanager` doesn't have `2.3-dev` branch.
