### PR TITLE
Added a reset for the Engine's internal images array

### DIFF
--- a/lib/PHPPdf/Core/Engine/ZF/Engine.php
+++ b/lib/PHPPdf/Core/Engine/ZF/Engine.php
@@ -184,5 +184,6 @@ class Engine extends AbstractEngine
         $this->graphicsContexts = array();
         $this->outlines = array();
         $this->zendPdf = null;
+        $this->images = array();
     }
 }


### PR DESCRIPTION
The engine currently keeps a hash of `path =>  data` presumably to allow optimizing for header/footer images on multilpe pages.

We are using the PHPdf library with the Symfony Bundle. We wrote a console command that runs forever, and generates single-page PDF's in a loop. Each page has a QR code, which get generated on disk in the same loop cycle.

With the current Engine, we have two options, both problematic:
- If we use the same filename for the QR code images, only the first image wll ever be loaded from disk
- If we use different filenames for the QR code images, all images will remain in the Engine memory and never be cleared.

This patch simply clears the internal Images array on `reset()`.
