### PR TITLE
Update ZF2 version constraints and remove unnecesary requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,15 @@
             "name":     "Piotr Śliwa",
             "homepage": "http://ohey.pl",
             "email":    "peter.pl7@gmail.com"
-        }     
+        }
     ],
     "require": {
-        "zendframework/zendpdf":  ">=2.0.0,<2.4",
-        "zendframework/zend-cache":  ">=2.0.0,<2.4",
-        "zendframework/zend-memory": ">=2.0.0,<2.4"
+        "zendframework/zendpdf":  "~2.0.0",
+        "zendframework/zend-cache":  "^2.0"
     },
     "require-dev": {
-        "zendframework/zend-barcode": ">=2.0.0,<2.4",
-        "zendframework/zend-validator": ">=2.0.0,<2.4",
+        "zendframework/zend-barcode": "^2.0",
+        "zendframework/zend-validator": "^2.0",
         "imagine/Imagine": ">=0.2.0,<0.6.0"
     },
     "suggest": {


### PR DESCRIPTION
ZF2 won't introduce BC break for Cache component, so its version constrain can be relaxed. Now it's possible to use this library with newer ZF2 versions (i.e. 2.4 LTS) or 2.5 (PHP 5.5+).

zendframework/zend-memory is required by zendframework/zendpdf - - so there is no need to specify it here as well.

zendframework/zendpdf is [not supported anymore](https://github.com/zendframework/ZendPdf/issues/13#issuecomment-23049992) but just in case I've updated constraint to allow patch versions: 2.0.X