### PR TITLE
🔦 More relevant exception messages for colors, fonts and pdf files

### DIFF
--- a/lib/PHPPdf/Exception/InvalidResourceException.php
+++ b/lib/PHPPdf/Exception/InvalidResourceException.php
@@ -15,31 +15,37 @@ class InvalidResourceException extends InvalidArgumentException
 {
     public static function invalidColorException($color, \Exception $previous = null)
     {
-        return new self(sprintf('Color "%s" not found.', $color), 0, $previous);
+        $message = 'Color "%s" is invalid.'.($previous ? ' '.$previous->getMessage() : '');
+
+        return new self(sprintf($message, $color), 0, $previous);
     }
-    
+
     public static function invalidImageException($imagePath, \Exception $previous = null)
     {
         $message = 'Image "%s" can\'t be initialized.'.($previous ? ' '.$previous->getMessage() : '');
 
         return new self(sprintf($message, $imagePath), 0, $previous);
     }
-    
+
     public static function unsupportetImageTypeException($imagePath)
     {
         return new self(sprintf('Image type of "%s" is not supported. Supported types: jpeg, png and tiff.', $imagePath));
     }
-    
+
     public static function invalidFontException($fontData, \Exception $previous = null)
     {
-        return new self(sprintf('Font "%s" not found.', $fontData), 0, $previous);
+        $message = 'Font "%s" is invalid.'.($previous ? ' '.$previous->getMessage() : '');
+
+        return new self(sprintf($message, $fontData), 0, $previous);
     }
-    
+
     public static function invalidPdfFileException($file, \Exception $previous = null)
     {
-        return new self(sprintf('Error while loading pdf document from "%s".', $file), 0, $previous);
+        $message = 'PDF file "%s" is invalid.'.($previous ? ' '.$previous->getMessage() : '');
+
+        return new self(sprintf($message, $file), 0, $previous);
     }
-    
+
     public static function fileDosntExistException($file)
     {
         return new self(sprintf('File "%s" dosn\'t exist.', $file));


### PR DESCRIPTION
I based my changes on what you did for `invalidImageException` method. Concatening `$previous` exception message if it is not `null`. 