### PR TITLE
Choose endianness for conversion

### DIFF
--- a/lib/PHPPdf/Core/Engine/ZF/GraphicsContext.php
+++ b/lib/PHPPdf/Core/Engine/ZF/GraphicsContext.php
@@ -371,7 +371,7 @@ class GraphicsContext extends AbstractGraphicsContext
             $action = \ZendPdf\Action\GoToAction::create($destination);
             
             //convert from input encoding to UTF-16
-            $name = iconv($this->encoding, 'UTF-16', $name);
+            $name = iconv($this->encoding, 'UTF-16BE', $name);
             
             $outline = \ZendPdf\Outline\AbstractOutline::create($name, $action);
             

--- a/tests/PHPPdf/Test/Core/Engine/ZF/GraphicsContextTest.php
+++ b/tests/PHPPdf/Test/Core/Engine/ZF/GraphicsContextTest.php
@@ -559,7 +559,7 @@ class GraphicsContextTest extends \PHPPdf\PHPUnit\Framework\TestCase
     
     private function assertOutline($expectedName, $expectedPage, $expectedTop, $actualOutline)
     {
-        $this->assertEquals(iconv(self::ENCODING, 'UTF-16', $expectedName), $actualOutline->getTitle());
+        $this->assertEquals(iconv(self::ENCODING, 'UTF-16BE', $expectedName), $actualOutline->getTitle());
         
         $target = $actualOutline->getTarget();
         


### PR DESCRIPTION
According to that message on stackoverflow (http://stackoverflow.com/questions/8923866/convert-utf8-to-utf16-using-iconv#8924403), choosing which endianness we want to use remove the BOM from the string.
The BOM was generated in the bookmarks text during the generation. When forcing the endianness, the BOM is no longer rendered.

See #102
