### PR TITLE
imagedestroy needs the recource as parameter

### DIFF
--- a/lib/PHPPdf/Core/Engine/Imagine/GraphicsContext.php
+++ b/lib/PHPPdf/Core/Engine/Imagine/GraphicsContext.php
@@ -598,7 +598,7 @@ class GraphicsContext extends AbstractGraphicsContext
         ob_start();
         imagepng($imageResource);
         $image = ob_get_clean();
-        @imagedestroy($image);
+        @imagedestroy($imageResource);
         
         $image = $this->imagine->load($image);
         $image = $image->resize(new Box($image->getSize()->getWidth()/2, $image->getSize()->getHeight()/2));


### PR DESCRIPTION
imagedestroy needs the recource as parameter not the content of the image.
http://php.net/manual/en/function.imagedestroy.php