### PR TITLE
Support APCu cache implementation.

### DIFF
--- a/lib/PHPPdf/Cache/CacheImpl.php
+++ b/lib/PHPPdf/Cache/CacheImpl.php
@@ -21,6 +21,7 @@ class CacheImpl implements Cache
 {
     const ENGINE_FILE = 'File';
     const ENGINE_APC = 'Apc';
+    const ENGINE_APCU = 'Apcu';
     const ENGINE_MEMCACHED = 'Memcached';
     const ENGINE_FILESYSTEM = 'Filesystem';
     


### PR DESCRIPTION
For PHP 5.6+ and 7 that use *Opcache* and *APCu* as a replacement for *APC*

```
NOTICE: PHP message: PHP Fatal error:  Uncaught Zend\Cache\Exception\ExtensionNotLoadedException: Missing ext/apc in /var/www/html/vendor/zendframework/zend-cache/src/Storage/Adapter/Apc.php:48
```