### PR TITLE
Make lib PHP 7.4 compatible

### DIFF
--- a/lib/PHPPdf/Core/Formatter/StandardPositionFormatter.php
+++ b/lib/PHPPdf/Core/Formatter/StandardPositionFormatter.php
@@ -27,7 +27,7 @@ class StandardPositionFormatter extends BaseFormatter
             list($x, $y) = $boundary->getFirstPoint()->toArray();
 
             $attributesSnapshot = $node->getAttributesSnapshot();
-            $diffWidth = $node->getWidth() - $attributesSnapshot['width'];
+            $diffWidth = $node->getWidth() - ($attributesSnapshot ? $attributesSnapshot['width'] : 0);
             $width = $node->getWidth();
             $x += $width;
             $yEnd = $y - $node->getHeight();


### PR DESCRIPTION
Hi! Currently there is an error with PHP 7.4:
`Trying to access array offset on value of type null`.

This small adjustment fixes the issue.